### PR TITLE
don't special case the console username

### DIFF
--- a/src/main/java/net/alpenblock/bungeeperms/PermissionsChecker.java
+++ b/src/main/java/net/alpenblock/bungeeperms/PermissionsChecker.java
@@ -15,40 +15,12 @@ public class PermissionsChecker
      */
     public boolean hasPerm(String sender, String permission)
     {
-        if (!sender.equalsIgnoreCase("CONSOLE"))
+        User u = pm().getUser(sender);
+        if (u == null)
         {
-            User u = pm().getUser(sender);
-            if (u == null)
-            {
-                return false;
-            }
-            return u.hasPerm(permission);
+            return false;
         }
-        return false;
-    }
-
-    /**
-     * Checks if a user (or console) has a specific permission (globally). If sender is console this function return true.
-     *
-     * @param sender the command sender to check a permission for
-     * @param permission the permission to check
-     * @return the result of the permission check
-     */
-    public boolean hasPermOrConsole(String sender, String permission)
-    {
-        if (sender.equalsIgnoreCase("CONSOLE"))
-        {
-            return true;
-        }
-        else
-        {
-            User u = pm().getUser(sender);
-            if (u == null)
-            {
-                return false;
-            }
-            return u.hasPerm(permission);
-        }
+        return u.hasPerm(permission);
     }
 
     /**
@@ -61,53 +33,18 @@ public class PermissionsChecker
      */
     public boolean hasPermOnServer(String sender, String permission, String server)
     {
-        if (!sender.equalsIgnoreCase("CONSOLE"))
+        User u = pm().getUser(sender);
+        if (u == null)
         {
-            User u = pm().getUser(sender);
-            if (u == null)
-            {
-                return false;
-            }
-
-            if (server == null)
-            {
-                return hasPerm(sender, permission);
-            }
-
-            return u.hasPermOnServer(permission, server);
+            return false;
         }
-        return false;
-    }
 
-    /**
-     * Checks if a user (or console) has a specific permission on the given server.
-     *
-     * @param sender the command sender to check a permission for
-     * @param permission the permission to check
-     * @param server the server for additional permissions
-     * @return the result of the permission check
-     */
-    public boolean hasPermOrConsoleOnServer(String sender, String permission, String server)
-    {
-        if (sender.equalsIgnoreCase("CONSOLE"))
+        if (server == null)
         {
-            return true;
+            return hasPerm(sender, permission);
         }
-        else
-        {
-            User u = pm().getUser(sender);
-            if (u == null)
-            {
-                return false;
-            }
 
-            if (server == null)
-            {
-                return hasPerm(sender, permission);
-            }
-
-            return u.hasPermOnServer(permission, server);
-        }
+        return u.hasPermOnServer(permission, server);
     }
 
     /**
@@ -121,64 +58,23 @@ public class PermissionsChecker
      */
     public boolean hasPermOnServerInWorld(String sender, String permission, String server, String world)
     {
-        if (!sender.equalsIgnoreCase("CONSOLE"))
+        User u = pm().getUser(sender);
+        if (u == null)
         {
-            User u = pm().getUser(sender);
-            if (u == null)
-            {
-                return false;
-            }
-
-            if (server == null)
-            {
-                return hasPerm(sender, permission);
-            }
-
-            if (world == null)
-            {
-                return hasPermOnServer(sender, permission, server);
-            }
-
-            return u.hasPermOnServerInWorld(permission, server, world);
+            return false;
         }
-        return false;
-    }
 
-    /**
-     * Checks if a user (or console) has a specific permission on the given server and in the given world.
-     *
-     * @param sender the command sender to check a permission for
-     * @param permission the permission to check
-     * @param server the server for additional permissions
-     * @param world the world for additional permissions
-     * @return the result of the permission check
-     */
-    public boolean hasPermOrConsoleOnServerInWorld(String sender, String permission, String server, String world)
-    {
-        if (sender.equalsIgnoreCase("CONSOLE"))
+        if (server == null)
         {
-            return true;
+            return hasPerm(sender, permission);
         }
-        else
+
+        if (world == null)
         {
-            User u = pm().getUser(sender);
-            if (u == null)
-            {
-                return false;
-            }
-
-            if (server == null)
-            {
-                return hasPerm(sender, permission);
-            }
-
-            if (world == null)
-            {
-                return hasPermOnServer(sender, permission, server);
-            }
-
-            return u.hasPermOnServerInWorld(permission, server, world);
+            return hasPermOnServer(sender, permission, server);
         }
+
+        return u.hasPermOnServerInWorld(permission, server, world);
     }
 
 //with wrapped command senders
@@ -191,7 +87,7 @@ public class PermissionsChecker
      */
     public boolean hasPerm(Sender sender, String permission)
     {
-        if (!sender.getName().equalsIgnoreCase("CONSOLE"))
+        if (!sender.isConsole())
         {
             User u = pm().getUser(sender.getName());
             if (u == null)
@@ -212,7 +108,7 @@ public class PermissionsChecker
      */
     public boolean hasPermOrConsole(Sender sender, String permission)
     {
-        if (sender.getName().equalsIgnoreCase("CONSOLE"))
+        if (sender.isConsole())
         {
             return true;
         }
@@ -236,22 +132,18 @@ public class PermissionsChecker
      */
     public boolean hasPermOnServer(Sender sender, String permission)
     {
-        if (!sender.getName().equalsIgnoreCase("CONSOLE"))
+        User u = pm().getUser(sender.getName());
+        if (u == null)
         {
-            User u = pm().getUser(sender.getName());
-            if (u == null)
-            {
-                return false;
-            }
-
-            if (sender.getServer() == null)
-            {
-                return hasPerm(sender, permission);
-            }
-
-            return u.hasPermOnServer(sender, permission, sender.getServer());
+            return false;
         }
-        return false;
+
+        if (sender.getServer() == null)
+        {
+            return hasPerm(sender, permission);
+        }
+
+        return u.hasPermOnServer(sender, permission, sender.getServer());
     }
 
     /**
@@ -263,7 +155,7 @@ public class PermissionsChecker
      */
     public boolean hasPermOrConsoleOnServer(Sender sender, String permission)
     {
-        if (sender.getName().equalsIgnoreCase("CONSOLE"))
+        if (sender.isConsole())
         {
             return true;
         }
@@ -293,27 +185,23 @@ public class PermissionsChecker
      */
     public boolean hasPermOnServerInWorld(Sender sender, String permission)
     {
-        if (!sender.getName().equalsIgnoreCase("CONSOLE"))
+        User u = pm().getUser(sender.getName());
+        if (u == null)
         {
-            User u = pm().getUser(sender.getName());
-            if (u == null)
-            {
-                return false;
-            }
-
-            if (sender.getServer() == null)
-            {
-                return hasPerm(sender, permission);
-            }
-
-            if (sender.getWorld()== null)
-            {
-                return hasPermOnServer(sender, permission);
-            }
-
-            return u.hasPermOnServerInWorld(sender, permission, sender.getServer(), sender.getWorld());
+            return false;
         }
-        return false;
+
+        if (sender.getServer() == null)
+        {
+            return hasPerm(sender, permission);
+        }
+
+        if (sender.getWorld() == null)
+        {
+            return hasPermOnServer(sender, permission);
+        }
+
+        return u.hasPermOnServerInWorld(sender, permission, sender.getServer(), sender.getWorld());
     }
 
     /**
@@ -325,7 +213,7 @@ public class PermissionsChecker
      */
     public boolean hasPermOrConsoleOnServerInWorld(Sender sender, String permission)
     {
-        if (sender.getName().equalsIgnoreCase("CONSOLE"))
+        if (sender.isConsole())
         {
             return true;
         }

--- a/src/main/java/net/alpenblock/bungeeperms/platform/bukkit/bridge/bridges/vault/Permission_BungeePerms.java
+++ b/src/main/java/net/alpenblock/bungeeperms/platform/bukkit/bridge/bridges/vault/Permission_BungeePerms.java
@@ -99,7 +99,7 @@ public class Permission_BungeePerms extends Permission
         String server = Statics.toLower(((BukkitConfig) BungeePerms.getInstance().getConfig()).getServername());
         world = Statics.toLower(world);
         permission = Statics.toLower(permission);
-        return BungeePerms.getInstance().getPermissionsChecker().hasPermOrConsoleOnServerInWorld(player, permission, server, world);
+        return BungeePerms.getInstance().getPermissionsChecker().hasPermOnServerInWorld(player, permission, server, world);
     }
 
     @Override


### PR DESCRIPTION
This fixes an security relevant issue  where the plugin wouldn't correctly apply the permission to a user named console. Particularly the plugin will allow that user to execute most commands. This pull request attempts to fix that.

There is a minecraft account with the name console, but I guess the bigger problem would be for cracked servers.