### PR TITLE
specify api-version

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: net.alpenblock.bungeeperms.platform.bukkit.BukkitPlugin
 version: '${build.fullversion.resource}'
 author: [wea_ondara, AuroraRainbow]
 load: startup
+api-version: '1.13'
 
 softdepend: [PlaceholderAPI, Vault, WorldEdit, AsyncWorldEdit, FastAsyncWorldEdit, Essentials]
 


### PR DESCRIPTION
Specifying an api-version of 1.13 keeps spigot/paper 1.13+ from complaining (issuing a warning) and enabling legacy support, versions prior to 1.13 are unaffected by this change which typically aids (startup) performance as spigot / paper doesn't have to enable an entire api (as long as no other plugin enables legacy support).